### PR TITLE
Loosen AWS Provider version constraint

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.33"
+      version = ">= 4.33, < 6.0"
     }
   }
 }


### PR DESCRIPTION
## Description
* Allow any AWS Provider version `>= 4.33, < 6.0`

## Breaking Changes
* None

## Testing
* `terraform apply` in my own AWS account after updating AWS Provider to `5.0.1`